### PR TITLE
[FLINK-18097][history-server]Cleaning job files in history server 1.9.1-szn

### DIFF
--- a/flink-annotations/pom.xml
+++ b/flink-annotations/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-clients/pom.xml
+++ b/flink-clients/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-elasticsearch-base/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch-base/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-elasticsearch2/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch2/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-elasticsearch5/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch5/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch6/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-filesystem/pom.xml
+++ b/flink-connectors/flink-connector-filesystem/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-gcp-pubsub/pom.xml
+++ b/flink-connectors/flink-connector-gcp-pubsub/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-kafka-0.10/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.10/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-kafka-0.11/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.11/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-kafka-0.8/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.8/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-kafka-0.9/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.9/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-kafka-base/pom.xml
+++ b/flink-connectors/flink-connector-kafka-base/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-kafka/pom.xml
+++ b/flink-connectors/flink-connector-kafka/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-nifi/pom.xml
+++ b/flink-connectors/flink-connector-nifi/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-rabbitmq/pom.xml
+++ b/flink-connectors/flink-connector-rabbitmq/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-connector-twitter/pom.xml
+++ b/flink-connectors/flink-connector-twitter/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-hadoop-compatibility/pom.xml
+++ b/flink-connectors/flink-hadoop-compatibility/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-hbase/pom.xml
+++ b/flink-connectors/flink-hbase/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-hcatalog/pom.xml
+++ b/flink-connectors/flink-hcatalog/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-jdbc/pom.xml
+++ b/flink-connectors/flink-jdbc/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-orc/pom.xml
+++ b/flink-connectors/flink-orc/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-sql-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-sql-connector-kafka-0.10/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka-0.10/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-sql-connector-kafka-0.11/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka-0.11/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-sql-connector-kafka-0.9/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka-0.9/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-connectors</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/flink-sql-connector-kafka/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<artifactId>flink-connectors</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-container/pom.xml
+++ b/flink-container/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-contrib/flink-connector-wikiedits/pom.xml
+++ b/flink-contrib/flink-connector-wikiedits/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-contrib</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-contrib/pom.xml
+++ b/flink-contrib/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-docs/pom.xml
+++ b/flink-docs/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-batch-sql-test/pom.xml
+++ b/flink-end-to-end-tests/flink-batch-sql-test/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-bucketing-sink-test/pom.xml
+++ b/flink-end-to-end-tests/flink-bucketing-sink-test/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-cli-test/pom.xml
+++ b/flink-end-to-end-tests/flink-cli-test/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-confluent-schema-registry/pom.xml
+++ b/flink-end-to-end-tests/flink-confluent-schema-registry/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
+++ b/flink-end-to-end-tests/flink-connector-gcp-pubsub-emulator-tests/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-dataset-allround-test/pom.xml
+++ b/flink-end-to-end-tests/flink-dataset-allround-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-dataset-fine-grained-recovery-test/pom.xml
+++ b/flink-end-to-end-tests/flink-dataset-fine-grained-recovery-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-datastream-allround-test/pom.xml
+++ b/flink-end-to-end-tests/flink-datastream-allround-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-distributed-cache-via-blob-test/pom.xml
+++ b/flink-end-to-end-tests/flink-distributed-cache-via-blob-test/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-e2e-test-utils/pom.xml
+++ b/flink-end-to-end-tests/flink-e2e-test-utils/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-elasticsearch2-test/pom.xml
+++ b/flink-end-to-end-tests/flink-elasticsearch2-test/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-elasticsearch5-test/pom.xml
+++ b/flink-end-to-end-tests/flink-elasticsearch5-test/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-elasticsearch6-test/pom.xml
+++ b/flink-end-to-end-tests/flink-elasticsearch6-test/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-heavy-deployment-stress-test/pom.xml
+++ b/flink-end-to-end-tests/flink-heavy-deployment-stress-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-high-parallelism-iterations-test/pom.xml
+++ b/flink-end-to-end-tests/flink-high-parallelism-iterations-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-local-recovery-and-allocation-test/pom.xml
+++ b/flink-end-to-end-tests/flink-local-recovery-and-allocation-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-metrics-availability-test/pom.xml
+++ b/flink-end-to-end-tests/flink-metrics-availability-test/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/pom.xml
+++ b/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-parent-child-classloading-test-lib-package/pom.xml
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test-lib-package/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-parent-child-classloading-test-program/pom.xml
+++ b/flink-end-to-end-tests/flink-parent-child-classloading-test-program/pom.xml
@@ -29,7 +29,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-plugins-test/pom.xml
+++ b/flink-end-to-end-tests/flink-plugins-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-queryable-state-test/pom.xml
+++ b/flink-end-to-end-tests/flink-queryable-state-test/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-quickstart-test/pom.xml
+++ b/flink-end-to-end-tests/flink-quickstart-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-state-evolution-test/pom.xml
+++ b/flink-end-to-end-tests/flink-state-evolution-test/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-stream-sql-test/pom.xml
+++ b/flink-end-to-end-tests/flink-stream-sql-test/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/pom.xml
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-end-to-end-tests</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/pom.xml
+++ b/flink-end-to-end-tests/flink-stream-stateful-job-upgrade-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-end-to-end-tests/flink-streaming-file-sink-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-file-sink-test/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-streaming-kafka-test-base/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kafka-test-base/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-streaming-kafka-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kafka-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-streaming-kafka010-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kafka010-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-streaming-kafka011-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kafka011-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
+++ b/flink-end-to-end-tests/flink-streaming-kinesis-test/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/flink-tpch-test/pom.xml
+++ b/flink-end-to-end-tests/flink-tpch-test/pom.xml
@@ -21,7 +21,7 @@ under the License.
 	<parent>
 		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-examples/flink-examples-batch/pom.xml
+++ b/flink-examples/flink-examples-batch/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-examples</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-gcp-pubsub/pom.xml
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-gcp-pubsub/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-examples-build-helper</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/pom.xml
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-examples-build-helper</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-twitter/pom.xml
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-twitter/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-examples-build-helper</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-examples/flink-examples-build-helper/pom.xml
+++ b/flink-examples/flink-examples-build-helper/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-examples</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-examples</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-examples/flink-examples-table/pom.xml
+++ b/flink-examples/flink-examples-table/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-examples</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-examples/pom.xml
+++ b/flink-examples/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/flink-azure-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-azure-fs-hadoop/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
+++ b/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/flink-hadoop-fs/pom.xml
+++ b/flink-filesystems/flink-hadoop-fs/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/flink-mapr-fs/pom.xml
+++ b/flink-filesystems/flink-mapr-fs/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/flink-oss-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-oss-fs-hadoop/pom.xml
@@ -21,7 +21,7 @@ under the License.
 	<parent>
 		<artifactId>flink-filesystems</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-filesystems/flink-s3-fs-base/pom.xml
+++ b/flink-filesystems/flink-s3-fs-base/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/flink-s3-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-s3-fs-hadoop/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/flink-swift-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-swift-fs-hadoop/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-filesystems</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-filesystems/pom.xml
+++ b/flink-filesystems/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-avro-confluent-registry/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<artifactId>flink-formats</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-formats/flink-avro/pom.xml
+++ b/flink-formats/flink-avro/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-csv/pom.xml
+++ b/flink-formats/flink-csv/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-json/pom.xml
+++ b/flink-formats/flink-json/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/flink-sequence-file/pom.xml
+++ b/flink-formats/flink-sequence-file/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-formats</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-formats/pom.xml
+++ b/flink-formats/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-fs-tests/pom.xml
+++ b/flink-fs-tests/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-libraries/flink-cep-scala/pom.xml
+++ b/flink-libraries/flink-cep-scala/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-libraries</artifactId>
-        <version>1.9.1-szn3</version>
+        <version>1.9.1-szn4</version>
         <relativePath>..</relativePath>
     </parent>
     

--- a/flink-libraries/flink-cep/pom.xml
+++ b/flink-libraries/flink-cep/pom.xml
@@ -26,7 +26,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-libraries</artifactId>
-        <version>1.9.1-szn3</version>
+        <version>1.9.1-szn4</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/flink-libraries/flink-gelly-examples/pom.xml
+++ b/flink-libraries/flink-gelly-examples/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-libraries</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-libraries/flink-gelly-scala/pom.xml
+++ b/flink-libraries/flink-gelly-scala/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-libraries</artifactId>
-        <version>1.9.1-szn3</version>
+        <version>1.9.1-szn4</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/flink-libraries/flink-gelly/pom.xml
+++ b/flink-libraries/flink-gelly/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-libraries</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-libraries/flink-state-processing-api/pom.xml
+++ b/flink-libraries/flink-state-processing-api/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-libraries</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-libraries/pom.xml
+++ b/flink-libraries/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-mesos/pom.xml
+++ b/flink-mesos/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 	

--- a/flink-metrics/flink-metrics-core/pom.xml
+++ b/flink-metrics/flink-metrics-core/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/flink-metrics-datadog/pom.xml
+++ b/flink-metrics/flink-metrics-datadog/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/flink-metrics-dropwizard/pom.xml
+++ b/flink-metrics/flink-metrics-dropwizard/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/flink-metrics-graphite/pom.xml
+++ b/flink-metrics/flink-metrics-graphite/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/flink-metrics-influxdb/pom.xml
+++ b/flink-metrics/flink-metrics-influxdb/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/flink-metrics-jmx/pom.xml
+++ b/flink-metrics/flink-metrics-jmx/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/flink-metrics-prometheus/pom.xml
+++ b/flink-metrics/flink-metrics-prometheus/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/flink-metrics-slf4j/pom.xml
+++ b/flink-metrics/flink-metrics-slf4j/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/flink-metrics-statsd/pom.xml
+++ b/flink-metrics/flink-metrics-statsd/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-metrics</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-metrics/pom.xml
+++ b/flink-metrics/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-ml-parent/flink-ml-api/pom.xml
+++ b/flink-ml-parent/flink-ml-api/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-ml-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 	</parent>
 
 	<artifactId>flink-ml-api</artifactId>

--- a/flink-ml-parent/flink-ml-lib/pom.xml
+++ b/flink-ml-parent/flink-ml-lib/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-ml-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 	</parent>
 
 	<artifactId>flink-ml-lib</artifactId>

--- a/flink-ml-parent/pom.xml
+++ b/flink-ml-parent/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-optimizer/pom.xml
+++ b/flink-optimizer/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<artifactId>flink-parent</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-queryable-state/flink-queryable-state-client-java/pom.xml
+++ b/flink-queryable-state/flink-queryable-state-client-java/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-queryable-state</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-queryable-state/flink-queryable-state-runtime/pom.xml
+++ b/flink-queryable-state/flink-queryable-state-runtime/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-queryable-state</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-queryable-state/pom.xml
+++ b/flink-queryable-state/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-quickstart/flink-quickstart-java/pom.xml
+++ b/flink-quickstart/flink-quickstart-java/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-quickstart</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-quickstart/flink-quickstart-scala/pom.xml
+++ b/flink-quickstart/flink-quickstart-scala/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-quickstart</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-quickstart/pom.xml
+++ b/flink-quickstart/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-runtime-web/pom.xml
+++ b/flink-runtime-web/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -164,7 +164,7 @@ class HistoryServerArchiveFetcher {
 		private final File webJobDir;
 		private final File webOverviewDir;
 
-		private static final String JSON_FILE_ENDING = ".json";
+		static final String JSON_FILE_ENDING = ".json";
 
 		JobArchiveFetcherTask(
 			List<HistoryServer.RefreshLocation> refreshDirs,

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerArchiveFetcher.java
@@ -255,20 +255,7 @@ class HistoryServerArchiveFetcher {
 								cachedArchives.add(jobID);
 							} catch (IOException e) {
 								LOG.error("Failure while fetching/processing job archive for job {}.", jobID, e);
-								// Make sure we do not include this job in the overview
-								try {
-									Files.delete(new File(webOverviewDir, jobID + JSON_FILE_ENDING).toPath());
-								} catch (IOException ioe) {
-									LOG.debug("Could not delete file from overview directory.", ioe);
-								}
-
-								// Clean up job files we may have created
-								File jobDirectory = new File(webJobDir, jobID);
-								try {
-									FileUtils.deleteDirectory(jobDirectory);
-								} catch (IOException ioe) {
-									LOG.debug("Could not clean up job directory.", ioe);
-								}
+								deleteJobFiles(jobID);
 							}
 						}
 					}
@@ -293,16 +280,35 @@ class HistoryServerArchiveFetcher {
 
 			cachedArchives.removeAll(jobsToRemove);
 			jobsToRemove.forEach(removedJobID -> {
-				try {
-					Files.deleteIfExists(new File(webOverviewDir, removedJobID + JSON_FILE_ENDING).toPath());
-					FileUtils.deleteDirectory(new File(webJobDir, removedJobID));
-				} catch (IOException e) {
-					LOG.error("Failure while removing job overview for job {}.", removedJobID, e);
-				}
+				deleteJobFiles(removedJobID);
 				deleteLog.add(new ArchiveEvent(removedJobID, ArchiveEventType.DELETED));
 			});
 
 			return deleteLog;
+		}
+
+		private void deleteJobFiles(String jobID) {
+			// Make sure we do not include this job in the overview
+			try {
+				Files.deleteIfExists(new File(webOverviewDir, jobID + JSON_FILE_ENDING).toPath());
+			} catch (IOException ioe) {
+				LOG.warn("Could not delete file from overview directory.", ioe);
+			}
+
+			// Clean up job files we may have created
+			File jobDirectory = new File(webJobDir, jobID);
+			try {
+				FileUtils.deleteDirectory(jobDirectory);
+			} catch (IOException ioe) {
+				LOG.warn("Could not clean up job directory.", ioe);
+			}
+
+			// Also clean up job json file in webJobDir
+			try {
+				Files.deleteIfExists(new File(webJobDir, jobID + JSON_FILE_ENDING).toPath());
+			} catch (IOException ioe) {
+				LOG.warn("Could not delete file from job directory.", ioe);
+			}
 		}
 
 	}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonFactory;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.DeserializationFeature;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.apache.commons.io.IOUtils;
@@ -61,6 +62,7 @@ import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertTrue;
 /**
  * Tests for the HistoryServer.
  */
@@ -70,7 +72,9 @@ public class HistoryServerTest extends TestLogger {
 	private static final JsonFactory JACKSON_FACTORY = new JsonFactory()
 		.enable(JsonGenerator.Feature.AUTO_CLOSE_TARGET)
 		.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
-	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
+		.enable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES);
+	private static final String JSON_FILE_ENDING = ".json";
 
 	@Rule
 	public final TemporaryFolder tmpFolder = new TemporaryFolder();
@@ -135,7 +139,7 @@ public class HistoryServerTest extends TestLogger {
 		try {
 			hs.start();
 			String baseUrl = "http://localhost:" + hs.getWebPort();
-			numExpectedArchivedJobs.await(10L, TimeUnit.SECONDS);
+			assertTrue(numExpectedArchivedJobs.await(10L, TimeUnit.SECONDS));
 
 			Assert.assertEquals(numJobs + numLegacyJobs, getJobsOverview(baseUrl).getJobs().size());
 		} finally {
@@ -183,7 +187,7 @@ public class HistoryServerTest extends TestLogger {
 		try {
 			hs.start();
 			String baseUrl = "http://localhost:" + hs.getWebPort();
-			numExpectedArchivedJobs.await(10L, TimeUnit.SECONDS);
+			assertTrue(numExpectedArchivedJobs.await(10L, TimeUnit.SECONDS));
 
 			Collection<JobDetails> jobs = getJobsOverview(baseUrl).getJobs();
 			Assert.assertEquals(numJobs, jobs.size());
@@ -194,10 +198,11 @@ public class HistoryServerTest extends TestLogger {
 				.map(JobID::toString)
 				.orElseThrow(() -> new IllegalStateException("Expected at least one existing job"));
 
+			assertHSFilesExistence(jobIdToDelete, true);
 			// delete one archive from jm
 			Files.deleteIfExists(jmDirectory.toPath().resolve(jobIdToDelete));
 
-			numExpectedExpiredJobs.await(10L, TimeUnit.SECONDS);
+			assertTrue(numExpectedExpiredJobs.await(10L, TimeUnit.SECONDS));
 
 			// check that archive is present in hs
 			Collection<JobDetails> jobsAfterDeletion = getJobsOverview(baseUrl).getJobs();
@@ -207,9 +212,17 @@ public class HistoryServerTest extends TestLogger {
 				.map(JobID::toString)
 				.filter(jobId -> jobId.equals(jobIdToDelete))
 				.count());
+			assertHSFilesExistence(jobIdToDelete, !cleanupExpiredJobs);
 		} finally {
 			hs.stop();
 		}
+	}
+
+	private void assertHSFilesExistence(String jobId, boolean fileExists){
+		Assert.assertEquals(fileExists, Files.exists(hsDirectory.toPath().resolve("jobs").resolve(jobId)));
+		Assert.assertEquals(fileExists, Files.isDirectory(hsDirectory.toPath().resolve("jobs").resolve(jobId)));
+		Assert.assertEquals(fileExists, Files.exists(hsDirectory.toPath().resolve("jobs").resolve(jobId + JSON_FILE_ENDING)));
+		Assert.assertEquals(fileExists, Files.exists(hsDirectory.toPath().resolve("overviews").resolve(jobId + JSON_FILE_ENDING)));
 	}
 
 	private void waitForArchivesCreation(int numJobs) throws InterruptedException {

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
@@ -62,6 +62,7 @@ import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.flink.runtime.webmonitor.history.HistoryServerArchiveFetcher.JobArchiveFetcherTask.JSON_FILE_ENDING;
 import static org.junit.Assert.assertTrue;
 /**
  * Tests for the HistoryServer.
@@ -74,7 +75,6 @@ public class HistoryServerTest extends TestLogger {
 		.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
 	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
 		.enable(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES);
-	private static final String JSON_FILE_ENDING = ".json";
 
 	@Rule
 	public final TemporaryFolder tmpFolder = new TemporaryFolder();

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-scala-shell/pom.xml
+++ b/flink-scala-shell/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-shaded-curator/pom.xml
+++ b/flink-shaded-curator/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-state-backends/flink-statebackend-rocksdb/pom.xml
+++ b/flink-state-backends/flink-statebackend-rocksdb/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-state-backends</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-state-backends/pom.xml
+++ b/flink-state-backends/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-sql-parser/pom.xml
+++ b/flink-table/flink-sql-parser/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
 		<artifactId>flink-table</artifactId>
 		<groupId>org.apache.flink</groupId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 	</parent>
 
 	<artifactId>flink-sql-parser</artifactId>

--- a/flink-table/flink-table-api-java-bridge/pom.xml
+++ b/flink-table/flink-table-api-java-bridge/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-api-java/pom.xml
+++ b/flink-table/flink-table-api-java/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-api-scala-bridge/pom.xml
+++ b/flink-table/flink-table-api-scala-bridge/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-api-scala/pom.xml
+++ b/flink-table/flink-table-api-scala/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-common/pom.xml
+++ b/flink-table/flink-table-common/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-planner-blink/pom.xml
+++ b/flink-table/flink-table-planner-blink/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-runtime-blink/pom.xml
+++ b/flink-table/flink-table-runtime-blink/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-uber-blink/pom.xml
+++ b/flink-table/flink-table-uber-blink/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/flink-table-uber/pom.xml
+++ b/flink-table/flink-table-uber/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-table</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-test-utils-parent/flink-test-utils-junit/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils-junit/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-test-utils-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-test-utils-parent/flink-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils/pom.xml
@@ -25,7 +25,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-test-utils-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-test-utils-parent/pom.xml
+++ b/flink-test-utils-parent/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-tests/pom.xml
+++ b/flink-tests/pom.xml
@@ -26,7 +26,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/flink-yarn/pom.xml
+++ b/flink-yarn/pom.xml
@@ -23,7 +23,7 @@ under the License.
 	<parent>
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-parent</artifactId>
-		<version>1.9.1-szn3</version>
+		<version>1.9.1-szn4</version>
 		<relativePath>..</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ under the License.
 
 	<groupId>org.apache.flink</groupId>
 	<artifactId>flink-parent</artifactId>
-	<version>1.9.1-szn3</version>
+	<version>1.9.1-szn4</version>
 
 	<name>flink</name>
 	<packaging>pom</packaging>
@@ -154,7 +154,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>force-shading</artifactId>
-			<version>1.9.1-szn3</version>
+			<version>1.9.1-szn4</version>
 		</dependency>
 
 		<!-- Root dependencies for all projects -->

--- a/tools/change-version.sh
+++ b/tools/change-version.sh
@@ -17,8 +17,8 @@
 # limitations under the License.
 ################################################################################
 
-OLD="1.9.1-szn2"
-NEW="1.9.1-szn3"
+OLD="1.9.1-szn3"
+NEW="1.9.1-szn4"
 
 
 HERE=` basename "$PWD"`

--- a/tools/force-shading/pom.xml
+++ b/tools/force-shading/pom.xml
@@ -38,7 +38,7 @@ under the License.
 
 	<groupId>org.apache.flink</groupId>
 	<artifactId>force-shading</artifactId>
-	<version>1.9.1-szn3</version>
+	<version>1.9.1-szn4</version>
 
 	<packaging>jar</packaging>
 


### PR DESCRIPTION
Porting changes made in https://github.com/apache/flink/pull/12560 , issue [FLINK-18097](https://issues.apache.org/jira/browse/FLINK-18097) to 1.9.1-szn branch.
- history server json files cleaning
- test updated
- release number raised